### PR TITLE
Correcting README.md Contributor Guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To generate IDEA metadata (.iml and .ipr files), do the following:
 
 ## Contributing
 
-[Pull requests][] are welcome. Please see the [Contributor Guidelines][] for details. 
+[Pull requests][] are welcome. Please see the [Contributor Guidelines](CONTRIBUTING.md) for details. 
 
 ## Staying in touch
 


### PR DESCRIPTION
Previously was auto-linking to the blob version which would not always load.

Assuming this qualifies under an _Obvious Fix_ and hence no need to sign the CLA
